### PR TITLE
Fix ZDCF pair rejection logic to match Alexander 1997

### DIFF
--- a/src/correlation/zdcf.rs
+++ b/src/correlation/zdcf.rs
@@ -80,6 +80,9 @@ fn alcbin(
     let n_pairs = time_lags.len();
     let mut bins: Vec<Vec<(usize, usize)>> = Vec::new();
 
+    let mut used1 = vec![false; n1];
+    let mut used2 = vec![false; n2];
+
     let mut pfr = n_pairs / 2;
     let mut pmax = 0;
     let mut incr: i32 = -1;
@@ -88,8 +91,6 @@ fn alcbin(
         let mut i = pfr;
         loop {
             let mut current_bin: Vec<(usize, usize)> = Vec::new();
-            let mut used1 = vec![false; n1];
-            let mut used2 = vec![false; n2];
             let mut tij = time_lags[i].0;
 
             loop {


### PR DESCRIPTION
The original implementation of the `alcbin` subroutine incorrectly re-initialized the `used1` and `used2` arrays for each new bin. This allowed data points to be reused across different bins, violating the principle of statistically independent bins as described in Alexander (1997).

This commit moves the initialization of `used1` and `used2` to before the main binning loop in `alcbin`. This ensures that each data point is used only once throughout the entire binning process, making the bins statistically independent as intended.