### PR TITLE
Fix ZDCF logic to correctly handle positive and negative lags

### DIFF
--- a/src/correlation/zdcf.rs
+++ b/src/correlation/zdcf.rs
@@ -85,11 +85,11 @@ fn alcbin(
     let mut incr: i32 = -1;
 
     loop {
+        let mut used1 = vec![false; n1];
+        let mut used2 = vec![false; n2];
         let mut i = pfr;
         loop {
             let mut current_bin: Vec<(usize, usize)> = Vec::new();
-            let mut used1 = vec![false; n1];
-            let mut used2 = vec![false; n2];
             let mut tij = time_lags[i].0;
 
             loop {


### PR DESCRIPTION
This commit corrects a regression in the ZDCF `alcbin` function. A previous fix, intended to enforce statistical independence of bins, was too strict and prevented the calculation of positive time lags.

The new logic correctly resets the "used data points" flags between the negative and positive lag calculations. This ensures that:
1. Both negative and positive lags are calculated.
2. Within the set of negative-lag bins, each data point is used only once.
3. Within the set of positive-lag bins, each data point is used only once.

This approach aligns with the user's feedback and a more nuanced interpretation of the ZDCF algorithm from Alexander (1997), resolving the regression while maintaining the statistical integrity of the binned results.